### PR TITLE
Fix processing double twostars

### DIFF
--- a/Dependencies/coreUtils.js
+++ b/Dependencies/coreUtils.js
@@ -39,6 +39,7 @@ import {
     resetServerDataFrequently,
     resetServerDataTime,
     safeEligibleIDsFiltering,
+    addDoubleStarToVipIdsTxt,
     forceSkipMin2Stars,
     forceSkipMinPacks,
     text_verifiedLogo,
@@ -1015,34 +1016,37 @@ async function updateEligibleIDs(client){
         }
     }
 
-    const doubleStarForum = await client.channels.cache.get(channelID_2StarVerificationForum);
-    const doubleStarThreads = await doubleStarForum.threads.fetchActive();
-
-    for (let thread of doubleStarThreads.threads) {
-        const nestedThread = thread[1];
-
-        // Check if post contains any logo other skip
-        if (nestedThread.name.includes(text_notLikedLogo) || nestedThread.name.includes(text_waitingLogo) || nestedThread.name.includes(text_likedLogo) || nestedThread.name.includes(text_verifiedLogo)) {
-
-            const initialMessage = await getOldestMessage(nestedThread);
-            const contentSplit = initialMessage.content.split('\n');
-
-            const cleanDoubleStarThreadName = replaceAnyLogoWith(nestedThread.name, "");
-            const doubleStarPocketName = cleanDoubleStarThreadName.split(" ")[1];
-            const doubleStarCount = "5/5";
-
-            if(!safeEligibleIDsFiltering){ // except if safe filtering is off
-                var gpTwoStarCountArray = cleanDoubleStarThreadName.match(/\[(\d+\/\d+)\]/);
-                doubleStarCount = gpTwoStarCountArray.length > 1 ? gpTwoStarCountArray[1] : 2;
-            }
-
-            const doubleStarPocketID = contentSplit.find(line => line.includes('ID:'));
-            
-            if(doubleStarPocketID != undefined){
-                idList += `${doubleStarPocketID.replace("ID:","")} | ${doubleStarPocketName} | ${doubleStarCount}\n`;
+    if (addDoubleStarToVipIdsTxt) {
+        const doubleStarForum = await client.channels.cache.get(channelID_2StarVerificationForum);
+        const doubleStarThreads = await doubleStarForum.threads.fetchActive();
+    
+        for (let thread of doubleStarThreads.threads) {
+            const nestedThread = thread[1];
+    
+            // Check if post contains any logo other skip
+            if (nestedThread.name.includes(text_notLikedLogo) || nestedThread.name.includes(text_waitingLogo) || nestedThread.name.includes(text_likedLogo) || nestedThread.name.includes(text_verifiedLogo)) {
+    
+                const initialMessage = await getOldestMessage(nestedThread);
+                const contentSplit = initialMessage.content.split('\n');
+    
+                const cleanDoubleStarThreadName = replaceAnyLogoWith(nestedThread.name, "");
+                const doubleStarPocketName = cleanDoubleStarThreadName.split(" ")[1];
+                const doubleStarCount = "5/5";
+    
+                if(!safeEligibleIDsFiltering){ // except if safe filtering is off
+                    var gpTwoStarCountArray = cleanDoubleStarThreadName.match(/\[(\d+\/\d+)\]/);
+                    doubleStarCount = gpTwoStarCountArray.length > 1 ? gpTwoStarCountArray[1] : 2;
+                }
+    
+                const doubleStarPocketID = contentSplit.find(line => line.includes('ID:'));
+                
+                if(doubleStarPocketID != undefined){
+                    idList += `${doubleStarPocketID.replace("ID:","")} | ${doubleStarPocketName} | ${doubleStarCount}\n`;
+                }
             }
         }
     }
+
     console.log(text_Done)
 
     await updateGist(idList, gitGistGPName);

--- a/Dependencies/coreUtils.js
+++ b/Dependencies/coreUtils.js
@@ -839,6 +839,36 @@ function extractGPInfo(message) {
     };
 }
 
+function extractDoubleStarInfo(message) {
+    try {
+        const regexOwnerID = /<@(\d+)>/;
+        const regexAccountName = /found by (\S+)/;
+        const regexAccountID = /\((\d+)\)/;
+        const regexPackAmount = /\((\d+) packs/;
+    
+        const ownerIDMatch = message.match(regexOwnerID);
+        const accountNameMatch = message.match(regexAccountName);
+        const accountIDMatch = message.match(regexAccountID);
+        const packAmountMatch = message.match(regexPackAmount);
+    
+        const ownerID = ownerIDMatch ? ownerIDMatch[1] : "0000000000000000";
+        const accountName = accountNameMatch ? accountNameMatch[1] : "NoAccountName";
+        const accountID = accountIDMatch ? accountIDMatch[1] : "0000000000000000";
+        const packAmount = packAmountMatch ? packAmountMatch[1] : 0;
+    
+        console.log(`Extracted info - OwnerID: ${ownerID}, AccountName: ${accountName}, AccountID: ${accountID}, PackAmount: ${packAmount}`);
+    
+        return {
+            ownerID,
+            accountName,
+            accountID,
+            packAmount
+        };        
+    } catch (error) {
+        console.log(`❌ ERROR - Failed to extract double star info for message: ${message}` + error)
+    }
+}
+
 async function createForumPost(client, message, channelID, packName, titleName, ownerID, accountID, packAmount){
 
     try{
@@ -985,6 +1015,34 @@ async function updateEligibleIDs(client){
         }
     }
 
+    const doubleStarForum = await client.channels.cache.get(channelID_2StarVerificationForum);
+    const doubleStarThreads = await doubleStarForum.threads.fetchActive();
+
+    for (let thread of doubleStarThreads.threads) {
+        const nestedThread = thread[1];
+
+        // Check if post contains any logo other skip
+        if (nestedThread.name.includes(text_notLikedLogo) || nestedThread.name.includes(text_waitingLogo) || nestedThread.name.includes(text_likedLogo) || nestedThread.name.includes(text_verifiedLogo)) {
+
+            const initialMessage = await getOldestMessage(nestedThread);
+            const contentSplit = initialMessage.content.split('\n');
+
+            const cleanDoubleStarThreadName = replaceAnyLogoWith(nestedThread.name, "");
+            const doubleStarPocketName = cleanDoubleStarThreadName.split(" ")[1];
+            const doubleStarCount = "5/5";
+
+            if(!safeEligibleIDsFiltering){ // except if safe filtering is off
+                var gpTwoStarCountArray = cleanDoubleStarThreadName.match(/\[(\d+\/\d+)\]/);
+                doubleStarCount = gpTwoStarCountArray.length > 1 ? gpTwoStarCountArray[1] : 2;
+            }
+
+            const doubleStarPocketID = contentSplit.find(line => line.includes('ID:'));
+            
+            if(doubleStarPocketID != undefined){
+                idList += `${doubleStarPocketID.replace("ID:","")} | ${doubleStarPocketName} | ${doubleStarCount}\n`;
+            }
+        }
+    }
     console.log(text_Done)
 
     await updateGist(idList, gitGistGPName);
@@ -1509,6 +1567,7 @@ export {
     sendStatusHeader,
     inactivityCheck,
     extractGPInfo,
+    extractDoubleStarInfo,
     createForumPost,
     markAsDead, 
     updateEligibleIDs,

--- a/config.js
+++ b/config.js
@@ -70,6 +70,7 @@ const outputUserDataOnGitGist = true;
 // =========================================== ELIGIBLES IDs ===========================================
 // If some ppl in your group are running Min2Stars : 2 and some others 3, that flags all the GPs as 5/5 in the list to avoid to auto remove bot from kicking 2/5 for those who are at Min2Stars : 3
 const safeEligibleIDsFiltering = true; // true = all flagged as 5/5
+const addDoubleStarToVipIdsTxt = false; // true = add double star pack account usernames to vip ids txt for GP Test Mode
 
 // =========================================== FORCE SKIP ===========================================
 // Allows you to bypass GP based on Packs Amount, Exemple : forceSkipMin2Stars 2 & forceSkipMinPacks 2 will 
@@ -182,6 +183,7 @@ export {
     resetServerDataFrequently,
     resetServerDataTime,
     safeEligibleIDsFiltering,
+    addDoubleStarToVipIdsTxt,
     forceSkipMin2Stars,
     forceSkipMinPacks,
     text_verifiedLogo,

--- a/index.mjs
+++ b/index.mjs
@@ -104,6 +104,7 @@ import {
     sendStatusHeader,
     inactivityCheck,
     extractGPInfo,
+    extractDoubleStarInfo,
     createForumPost,
     markAsDead, 
     updateEligibleIDs,
@@ -1129,7 +1130,7 @@ client.on("messageCreate", async (message) => {
 
             if(channelID_2StarVerificationForum == ""){return;}
 
-            var GPInfo = extractGPInfo(message.content);
+            var GPInfo = extractDoubleStarInfo(message.content);
 
             var ownerID = GPInfo.ownerID;
             var accountName = GPInfo.accountName;


### PR DESCRIPTION
- Create a separate function to extract the relevant information from double two star webhook messages
- Control whether to add double two star account usernames & ids to the vip_ids gist/txt file